### PR TITLE
Hub rechecking polling

### DIFF
--- a/pkg/core/scanstatus.go
+++ b/pkg/core/scanstatus.go
@@ -23,21 +23,9 @@ package core
 
 import "fmt"
 
-// ScanStatus describes the state of an image -- have we checked the hub for it?
-// Have we scanned it?  Are we scanning it?
+// ScanStatus describes the state of an image in perceptor
 type ScanStatus int
 
-// Allowed transitions:
-//  - Unknown -> InHubCheckQueue
-//  - InHubCheckQueue -> CheckingHub
-//  - CheckingHub -> InQueue
-//  - CheckingHub -> Complete
-//  - InQueue -> RunningScanClient
-//  - RunningScanClient -> Error
-//  - RunningScanClient -> RunningHubScan
-//  - RunningHubScan -> Error
-//  - RunningHubScan -> Complete
-//  - Error -> ??? throw it back into the queue?
 const (
 	ScanStatusUnknown           ScanStatus = iota
 	ScanStatusInHubCheckQueue   ScanStatus = iota


### PR DESCRIPTION
Every <n> minutes, run through all the images that already have completed scans, and re-pull their hub info.  

This will handle the case that additional vulnerabilities or policy violations have turned up after the original scan.

Throttle these to wait 5 seconds between image pulling, so as to avoid overloading the hub with http requests.