### PR TITLE
move metrics registration out of http setup

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -27,13 +27,11 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
 func SetupHTTPServer(responder Responder) {
 	// state of the program
-	http.Handle("/metrics", prometheus.Handler())
 	http.HandleFunc("/model", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
 			header := w.Header()

--- a/pkg/core/executable.go
+++ b/pkg/core/executable.go
@@ -60,6 +60,8 @@ func RunPerceptor() {
 	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
 	prometheus.Unregister(prometheus.NewGoCollector())
 
+	http.Handle("/metrics", prometheus.Handler())
+
 	if config.UseMockMode {
 		responder := api.NewMockResponder()
 		api.SetupHTTPServer(responder)


### PR DESCRIPTION
Because prometheus gets weird about which metrics it will and won't include when reusing this code from piftester.

This allows piftester to register the prometheus handler whenever it wants.

The REAL solution would be to use a better muxing library or something.  Or maybe not use the global http.