### PR TITLE
allow image priority to be increased but not decreased

### DIFF
--- a/pkg/core/model/model.go
+++ b/pkg/core/model/model.go
@@ -92,6 +92,10 @@ func (model *Model) AddImage(image Image, priority int) {
 	if added {
 		model.ImagePriority[image.Sha] = priority
 		model.SetImageScanStatus(image.Sha, ScanStatusInHubCheckQueue)
+	} else {
+		if priority > model.ImagePriority[image.Sha] {
+			model.ImagePriority[image.Sha] = priority
+		}
 	}
 }
 


### PR DESCRIPTION
This handles the case where an image is first seen outside of a pod, but later is seen in a pod.