### PR TITLE
Specify hub project name version

### DIFF
--- a/api/swagger-spec.json
+++ b/api/swagger-spec.json
@@ -356,6 +356,19 @@
         "Sha": {
           "description": "The Docker sha of the image",
           "type": "string"
+        },
+        "Priority": {
+          "description": "The priority to scan the image where 1 has lowest priority",
+          "type": "integer",
+          "format": "int64"
+        },
+        "BlackDuckProjectName": {
+          "description": "Name to display as the Project Name in BlackDuck",
+          "type": "string"
+        },
+        "BlackDuckProjectVersion": {
+          "description": "Version to use in BlackDuck scan",
+          "type": "string"
         }
       },
       "x-go-package": "github.com/blackducksoftware/perceptor/pkg/api"
@@ -382,7 +395,8 @@
         "Sha",
         "HubProjectName",
         "HubProjectVersionName",
-        "HubScanName"
+        "HubScanName",
+        "Priority"
       ],
       "properties": {
         "Repository": {
@@ -408,6 +422,11 @@
         "HubScanName": {
           "description": "The Hub scan name",
           "type": "string"
+        },
+        "Priority": {
+          "description": "The Priority of the scan where 1 has the lowest priority",
+          "type": "integer",
+          "format": "int64"
         }
       },
       "x-go-package": "github.com/blackducksoftware/perceptor/pkg/api"

--- a/pkg/api/image.go
+++ b/pkg/api/image.go
@@ -23,13 +23,15 @@ package api
 
 // Image .....
 type Image struct {
-	Repository string
-	Tag        string
-	Sha        string
-	Priority   *int
+	Repository              string
+	Tag                     string
+	Sha                     string
+	Priority                *int
+	BlackDuckProjectName    string
+	BlackDuckProjectVersion string
 }
 
 // NewImage .....
-func NewImage(repository string, tag string, sha string, priority *int) *Image {
-	return &Image{Repository: repository, Tag: tag, Sha: sha, Priority: priority}
+func NewImage(repository string, tag string, sha string, priority *int, blackDuckProjectName string, blackDuckProjectVersion string) *Image {
+	return &Image{Repository: repository, Tag: tag, Sha: sha, Priority: priority, BlackDuckProjectName: blackDuckProjectName, BlackDuckProjectVersion: blackDuckProjectVersion}
 }

--- a/pkg/core/apimapper.go
+++ b/pkg/core/apimapper.go
@@ -38,7 +38,7 @@ func APIImageToCoreImage(apiImage api.Image) (*model.Image, error) {
 	if apiImage.Priority != nil {
 		priority = *apiImage.Priority
 	}
-	return model.NewImage(apiImage.Repository, apiImage.Tag, sha, priority), nil
+	return model.NewImage(apiImage.Repository, apiImage.Tag, sha, priority, apiImage.BlackDuckProjectName, apiImage.BlackDuckProjectVersion), nil
 }
 
 // APIContainerToCoreContainer .....

--- a/pkg/core/model/actions_test.go
+++ b/pkg/core/model/actions_test.go
@@ -33,11 +33,11 @@ import (
 
 var (
 	sha1   = DockerImageSha("sha1")
-	image1 = *NewImage("image1", "1", sha1, 1)
+	image1 = *NewImage("image1", "1", sha1, 1, "Project Image1", "1.0")
 	sha2   = DockerImageSha("sha2")
-	image2 = *NewImage("image2", "2", sha2, 2)
+	image2 = *NewImage("image2", "2", sha2, 2, "Project Image2", "2.0")
 	sha3   = DockerImageSha("sha3")
-	image3 = *NewImage("image3", "3", sha3, 3)
+	image3 = *NewImage("image3", "3", sha3, 3, "Project Image3". "3.0")
 	cont1  = *NewContainer(image1, "cont1")
 	cont2  = *NewContainer(image2, "cont2")
 	cont3  = *NewContainer(image3, "cont3")
@@ -50,7 +50,7 @@ var (
 
 var (
 	testSha   = DockerImageSha("sha1")
-	testImage = Image{Repository: "image1", Tag: "", Sha: testSha, Priority: 1}
+	testImage = Image{Repository: "image1", Tag: "", Sha: testSha, Priority: 1, BlackDuckProjectName: "Project Image1", BlackDuckProjectVersion: "1.0"}
 	testCont  = Container{Image: testImage}
 	testPod   = Pod{Namespace: "abc", Name: "def", UID: "fff", Containers: []Container{testCont}}
 )
@@ -106,7 +106,7 @@ func RunActionTests() {
 			//  - image gets added to .Images
 			//  - image gets added to hub check queue
 			expected := *NewModel()
-			imageInfo := NewImageInfo(testSha, &RepoTag{Repository: "image1", Tag: ""}, 1)
+			imageInfo := NewImageInfo(testImage, &RepoTag{Repository: "image1", Tag: ""})
 			imageInfo.ScanStatus = ScanStatusUnknown
 			imageInfo.TimeOfLastStatusChange = actual.Images[testSha].TimeOfLastStatusChange
 			expected.Images[testSha] = imageInfo
@@ -149,7 +149,7 @@ func RunActionTests() {
 	Describe("FinishScanClient", func() {
 		It("handles failures", func() {
 			model := NewModel()
-			image := *NewImage("abc", "4.0", DockerImageSha("23bcf2dae3"), -1)
+			image := *NewImage("abc", "4.0", DockerImageSha("23bcf2dae3"), -1, "", "")
 			model.setImageScanStatus(image.Sha, ScanStatusInQueue)
 			model.setImageScanStatus(image.Sha, ScanStatusRunningScanClient)
 			err := model.finishRunningScanClient(&image, fmt.Errorf("oops, unable to run scan client"))
@@ -273,20 +273,27 @@ func RunActionTests() {
 			Expect(image.Repository).To(Equal("docker.io/mfenwickbd/perceptor"))
 		})
 
-		It("hub data", func() {
+		It("default hub data", func() {
 			sha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-			image := NewImage("abc", "latest", DockerImageSha(sha), 0)
+			image := NewImage("abc", "latest", DockerImageSha(sha), 0, "", "")
 			Expect(image.HubProjectName()).To(Equal("abc"))
 			Expect(image.HubProjectVersionName()).To(Equal("latest-" + sha[:20]))
 			Expect(image.HubScanName()).To(Equal(sha))
 		})
 		It("missing tag", func() {
 			sha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-			image := NewImage("abc", "", DockerImageSha(sha), 0)
+			image := NewImage("abc", "", DockerImageSha(sha), 0, "", "")
 			Expect(image.HubProjectName()).To(Equal("abc"))
 			Expect(image.HubProjectVersionName()).To(Equal(sha[:20]))
 			Expect(image.HubScanName()).To(Equal(sha))
 		})
+		It("specific hub data", func() {
+	    sha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	    image := NewImage("abc", "", DockerImageSha(sha), 0, "def", "ghi")
+	    Expect(image.HubProjectName()).To(Equal("def"))
+	    Expect(image.HubProjectVersionName()).To(Equal("ghi"))
+	    Expect(image.HubScanName()).To(Equal(sha))
+	  })
 	})
 	Describe("metrics", func() {
 		It("should handle metrics without panicing", func() {

--- a/pkg/core/model/actions_test.go
+++ b/pkg/core/model/actions_test.go
@@ -37,7 +37,7 @@ var (
 	sha2   = DockerImageSha("sha2")
 	image2 = *NewImage("image2", "2", sha2, 2, "Project Image2", "2.0")
 	sha3   = DockerImageSha("sha3")
-	image3 = *NewImage("image3", "3", sha3, 3, "Project Image3". "3.0")
+	image3 = *NewImage("image3", "3", sha3, 3, "Project Image3", "3.0")
 	cont1  = *NewContainer(image1, "cont1")
 	cont2  = *NewContainer(image2, "cont2")
 	cont3  = *NewContainer(image3, "cont3")
@@ -288,12 +288,12 @@ func RunActionTests() {
 			Expect(image.HubScanName()).To(Equal(sha))
 		})
 		It("specific hub data", func() {
-	    sha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	    image := NewImage("abc", "", DockerImageSha(sha), 0, "def", "ghi")
-	    Expect(image.HubProjectName()).To(Equal("def"))
-	    Expect(image.HubProjectVersionName()).To(Equal("ghi"))
-	    Expect(image.HubScanName()).To(Equal(sha))
-	  })
+			sha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+			image := NewImage("abc", "", DockerImageSha(sha), 0, "def", "ghi")
+			Expect(image.HubProjectName()).To(Equal("def"))
+			Expect(image.HubProjectVersionName()).To(Equal("ghi"))
+			Expect(image.HubScanName()).To(Equal(sha))
+		})
 	})
 	Describe("metrics", func() {
 		It("should handle metrics without panicing", func() {

--- a/pkg/core/model/actions_test.go
+++ b/pkg/core/model/actions_test.go
@@ -124,7 +124,7 @@ func RunActionTests() {
 			//  - all new images get added to hub check queue
 			expected := *NewModel()
 			expected.Pods[testPod.QualifiedName()] = testPod
-			imageInfo := NewImageInfo(testSha, &RepoTag{Repository: "image1", Tag: ""}, 1)
+			imageInfo := NewImageInfo(testImage, &RepoTag{Repository: "image1", Tag: ""})
 			imageInfo.ScanStatus = ScanStatusUnknown
 			imageInfo.TimeOfLastStatusChange = actual.Images[testSha].TimeOfLastStatusChange
 			expected.Images[testSha] = imageInfo

--- a/pkg/core/model/image.go
+++ b/pkg/core/model/image.go
@@ -27,15 +27,17 @@ import (
 
 // Image .....
 type Image struct {
-	Repository string
-	Tag        string
-	Sha        DockerImageSha
-	Priority   int
+	Repository              string
+	Tag                     string
+	Sha                     DockerImageSha
+	Priority                int
+	BlackDuckProjectName    string
+	BlackDuckProjectVersion string
 }
 
 // NewImage .....
-func NewImage(repository string, tag string, sha DockerImageSha, priority int) *Image {
-	return &Image{Repository: repository, Tag: tag, Sha: sha, Priority: priority}
+func NewImage(repository string, tag string, sha DockerImageSha, priority int, blackDuckProjectName string, blackDuckProjectVersion string) *Image {
+	return &Image{Repository: repository, Tag: tag, Sha: sha, Priority: priority, BlackDuckProjectName: blackDuckProjectName, BlackDuckProjectVersion: blackDuckProjectVersion}
 }
 
 func (image Image) shaPrefix() string {
@@ -46,11 +48,18 @@ func (image Image) shaPrefix() string {
 
 // HubProjectName .....
 func (image Image) HubProjectName() string {
+	if image.BlackDuckProjectName != "" {
+		return image.BlackDuckProjectName
+	}
 	return image.Repository
 }
 
 // HubProjectVersionName .....
 func (image Image) HubProjectVersionName() string {
+	if image.BlackDuckProjectVersion != "" {
+		return image.BlackDuckProjectVersion
+	}
+
 	tag := ""
 	if image.Tag != "" {
 		tag = image.Tag + "-"

--- a/pkg/core/model/imageinfo.go
+++ b/pkg/core/model/imageinfo.go
@@ -31,22 +31,26 @@ import (
 
 // ImageInfo .....
 type ImageInfo struct {
-	ScanStatus             ScanStatus
-	TimeOfLastStatusChange time.Time
-	TimeOfLastRefresh      time.Time
-	ScanResults            *hub.ScanResults
-	ImageSha               DockerImageSha
-	RepoTags               []*RepoTag
-	Priority               int
+	ScanStatus              ScanStatus
+	TimeOfLastStatusChange  time.Time
+	TimeOfLastRefresh       time.Time
+	ScanResults             *hub.ScanResults
+	ImageSha                DockerImageSha
+	RepoTags                []*RepoTag
+	Priority                int
+	BlackDuckProjectName    string
+	BlackDuckProjectVersion string
 }
 
 // NewImageInfo .....
-func NewImageInfo(sha DockerImageSha, repoTag *RepoTag, priority int) *ImageInfo {
+func NewImageInfo(image Image, repoTag *RepoTag) *ImageInfo {
 	imageInfo := &ImageInfo{
-		ScanResults: nil,
-		ImageSha:    sha,
-		RepoTags:    []*RepoTag{repoTag},
-		Priority:    priority,
+		ScanResults:             nil,
+		ImageSha:                image.Sha,
+		RepoTags:                []*RepoTag{repoTag},
+		Priority:                image.Priority,
+		BlackDuckProjectName:    image.BlackDuckProjectName,
+		BlackDuckProjectVersion: image.BlackDuckProjectVersion,
 	}
 	imageInfo.setScanStatus(ScanStatusUnknown)
 	return imageInfo
@@ -78,7 +82,7 @@ func (imageInfo *ImageInfo) TimeInCurrentScanStatus() time.Duration {
 // Image .....
 func (imageInfo *ImageInfo) Image() Image {
 	repoTag := imageInfo.FirstRepoTag()
-	return *NewImage(repoTag.Repository, repoTag.Tag, imageInfo.ImageSha, imageInfo.Priority)
+	return *NewImage(repoTag.Repository, repoTag.Tag, imageInfo.ImageSha, imageInfo.Priority, imageInfo.BlackDuckProjectName, imageInfo.BlackDuckProjectVersion)
 }
 
 // AddRepoTag .....

--- a/pkg/core/model/model.go
+++ b/pkg/core/model/model.go
@@ -390,7 +390,7 @@ func (model *Model) createImage(image Image) (bool, error) {
 		}
 		return added, nil
 	}
-	newInfo := NewImageInfo(image.Sha, &RepoTag{Repository: image.Repository, Tag: image.Tag}, image.Priority)
+	newInfo := NewImageInfo(image, &RepoTag{Repository: image.Repository, Tag: image.Tag})
 	model.Images[image.Sha] = newInfo
 	log.Debugf("added image %s to model", image.PullSpec())
 	return added, nil

--- a/pkg/core/model/modelextensions.go
+++ b/pkg/core/model/modelextensions.go
@@ -131,7 +131,7 @@ func coreContainerToAPIContainer(coreContainer Container) *api.Container {
 	image := coreContainer.Image
 	priority := image.Priority
 	return &api.Container{
-		Image: *api.NewImage(image.Repository, image.Tag, string(image.Sha), &priority),
+		Image: *api.NewImage(image.Repository, image.Tag, string(image.Sha), &priority, image.BlackDuckProjectName, image.BlackDuckProjectVersion),
 		Name:  coreContainer.Name,
 	}
 }

--- a/pkg/core/perceptor.go
+++ b/pkg/core/perceptor.go
@@ -345,7 +345,7 @@ func (pcp *Perceptor) PostFinishScan(job api.FinishedScanClientJob) error {
 		if err != nil {
 			log.Errorf("unable to record FinishScanClient for hub %s, image %s:", job.ImageSpec.HubURL, job.ImageSpec.HubScanName)
 		}
-		image := m.NewImage(job.ImageSpec.Repository, job.ImageSpec.Tag, m.DockerImageSha(job.ImageSpec.Sha), job.ImageSpec.Priority)
+		image := m.NewImage(job.ImageSpec.Repository, job.ImageSpec.Tag, m.DockerImageSha(job.ImageSpec.Sha), job.ImageSpec.Priority, job.ImageSpec.HubProjectName, job.ImageSpec.HubProjectVersionName)
 		pcp.model.FinishScanJob(image, scanErr)
 	}()
 	log.Debugf("handled finished scan job -- %v", job)


### PR DESCRIPTION
The project name and version used in BlackDuck could be customized
previously with caveats:
* The BlackDuck Project Name had to be the same as the Repository
* The BlackDuck Project Version was constructed using the Tag + "-" +
first 20 characters of the Sha

This change allows optional BlackDuck Project Name and BlackDuck Project
Version to be sent in the Image data block of the request body. The Name
and Version provided will override the default functionality previously
described.